### PR TITLE
fix(TM-1549): fix archive warnings for privacy info file

### DIFF
--- a/Updates/Classes/Resources/PrivacyInfo.xcprivacy
+++ b/Updates/Classes/Resources/PrivacyInfo.xcprivacy
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>CA92.1</string>
-			</array>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>APICategoryUserDefaults</string>
-		</dict>
-	</array>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array></array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Use the branch in Service Link and archive the app. 
Once the we do the validation, it should not throw any warnings.